### PR TITLE
allow passing arguments to Cluster()

### DIFF
--- a/flask_cassandra.py
+++ b/flask_cassandra.py
@@ -50,13 +50,13 @@ class CassandraCluster(object):
         else:
             app.teardown_request(self.teardown)
 
-    def connect(self):
+    def connect(self, **kwargs):
         log.debug("Connecting to CASSANDRA NODES {}".format(current_app.config['CASSANDRA_NODES']))
         if self.cluster is None:
             if isinstance(current_app.config['CASSANDRA_NODES'], (list, tuple)):
-                self.cluster = Cluster(current_app.config['CASSANDRA_NODES'])
+                self.cluster = Cluster(current_app.config['CASSANDRA_NODES'], **kwargs)
             elif isinstance(current_app.config['CASSANDRA_NODES'], (str, unicode)):
-                self.cluster = Cluster([current_app.config['CASSANDRA_NODES']])
+                self.cluster = Cluster([current_app.config['CASSANDRA_NODES']], **kwargs)
             else:
                 raise TypeError("CASSANDRA_NODES must be defined as a list, tuple, string, or unicode object.")
 


### PR DESCRIPTION
Hi!

I'd like to use an AuthProvider which should be an argument to Cluster(), but I can't pass arguments.
Here's my take at it. It's maybe wrong since I'm not used to dealing with Flask plugins.

Thanks!